### PR TITLE
feat: random of aspect ratio

### DIFF
--- a/src/pages/api/v3/random.ts
+++ b/src/pages/api/v3/random.ts
@@ -65,7 +65,7 @@ export const GET: APIRoute = async (APIContext) => {
       parsedAspectRatio,
       aspectRatioVariance,
     );
-    if (!Array.isArray(shigsOfRatio)) {
+    if (shigsOfRatio.length === 0) {
       // If no aspect ratio + variance match is found, find the closest aspect ratio we have
       const possibleRatios = Array.from(cachedAspectRatios.keys());
       const [closestRatio] = possibleRatios.sort(

--- a/src/pages/api/v3/random.ts
+++ b/src/pages/api/v3/random.ts
@@ -2,12 +2,60 @@ import { APIRoute } from "astro";
 
 import { GET as shiggyGetter } from "./shiggies/[id]/index";
 
-import getShiggies from "../../../utils/getShiggies";
+import getShiggies, { getSizes } from "../../../utils/getShiggies";
+
+// Allow caching of computed aspect ratios, so we don't have to recalculate on every request
+const cachedAspectRatios = new Map<number, string[]>();
+
+async function computeAspectRatios() {
+  const sizes = await getSizes();
+  for (const [id, dimensions] of Object.entries(sizes)) {
+    const ratio = dimensions.width / dimensions.height;
+
+    // Make sure that the ratio is available in the cache
+    if (!cachedAspectRatios.has(ratio)) {
+      cachedAspectRatios.set(ratio, []);
+    }
+
+    // Add the shiggy ID to the list of shiggies for that aspect ratio
+    cachedAspectRatios.get(ratio)!.push(id);
+  }
+}
 
 export const GET: APIRoute = async (APIContext) => {
   const allShiggies = await getShiggies();
 
-  const shig = allShiggies[Math.floor(Math.random() * allShiggies.length)];
+  // The ID of the final shiggy to be returned
+  let shig: string;
+  const aspectRatio = APIContext.url.searchParams.get("aspect-ratio");
+  if (aspectRatio === null) {
+    // If no aspect ratio is specified, return any random shiggy
+    shig = allShiggies[Math.floor(Math.random() * allShiggies.length)];
+  } else {
+    // Check if aspectRatio is a valid number
+    const parsedAspectRatio = Number(aspectRatio);
+    if (isNaN(parsedAspectRatio)) {
+      return new Response("aspect-ratio must be a number", { status: 400 });
+    }
+
+    // Check if cachedAspectRatios is populated and populate it if not
+    if (cachedAspectRatios.size === 0) {
+      await computeAspectRatios();
+    }
+
+    let shigsOfRatio = cachedAspectRatios.get(parsedAspectRatio);
+    if (!Array.isArray(shigsOfRatio)) {
+      // If no exact aspect ratio match is found, find the closest aspect ratio we have
+      const possibleRatios = Array.from(cachedAspectRatios.keys());
+      const [closestRatio] = possibleRatios.sort(
+        (a, b) =>
+          Math.abs(parsedAspectRatio - a) - Math.abs(parsedAspectRatio - b),
+      );
+      shigsOfRatio = cachedAspectRatios.get(closestRatio);
+    }
+
+    shig = shigsOfRatio![Math.floor(Math.random() * shigsOfRatio!.length)];
+  }
 
   APIContext.params = { id: shig };
 

--- a/src/pages/api/v3/sizes.ts
+++ b/src/pages/api/v3/sizes.ts
@@ -1,7 +1,10 @@
 import { APIRoute } from "astro";
-import { SHIGGY_DIR } from "../../../constants";
-import { join } from "path";
+import { getSizes } from "../../../utils/getShiggies.ts";
 
-export const GET: APIRoute = () => {
-  return new Response(Bun.file(join(SHIGGY_DIR, "sizes.json")));
+export const GET: APIRoute = async () => {
+  return new Response(JSON.stringify(await getSizes()), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
 };

--- a/src/utils/getShiggies.ts
+++ b/src/utils/getShiggies.ts
@@ -1,6 +1,12 @@
 import { join } from "path";
 import { SHIGGY_DIR } from "../constants";
 
-export default async function getShiggies() {
-  return (await Bun.file(join(SHIGGY_DIR, "shiggies.json")).json()) as string[];
+export default async function getShiggies(): Promise<string[]> {
+  return await Bun.file(join(SHIGGY_DIR, "shiggies.json")).json();
+}
+
+type ShiggySizeMap = { [key: string]: { width: number; height: number } };
+
+export async function getSizes(): Promise<ShiggySizeMap> {
+  return await Bun.file(join(SHIGGY_DIR, "sizes.json")).json();
 }


### PR DESCRIPTION
This pull request adds functionality that allows users to request a random image of a specific aspect ratio. Currently, the logic works as follows:

- Place all shiggies in a cache map based on their computed aspect ratio
- When a request comes in that specifies an aspect ratio, get a random shiggy of that aspect ratio
- If there are no shiggies of that exact aspect ratio, return a shiggy of the next closest aspect ratio.

I messed with a few ideas like grouping images with similar aspect ratios to improve selection, but this ended up not working super well as it merged some common aspect ratios. Someone more familiar with fuzzy grouping might have a better solution than I did to resolve that issue. In the meantime, an `aspect-ratio-variance` parameter is available that allows users to specify how much variance to use when filtering images to be randomly returned.

I did not implement tests as v3 does not have them, but can if requested.